### PR TITLE
🔀 :: (#112) - JusicoolTextField에서 오류 메시지가 버튼을 누르기 전에도 항상 표시되는 오류를 해결 하였습니

### DIFF
--- a/feature/signin/src/main/java/com/jusicool/signin/view/SignInScreen.kt
+++ b/feature/signin/src/main/java/com/jusicool/signin/view/SignInScreen.kt
@@ -112,7 +112,7 @@ private fun SignInScreen(
                 onTextChange = onPasswordChange,
                 placeHolder = "비밀번호를 입력해주세요",
                 isError = isPasswordError,
-                helperText = "아이디와 비밀번호를 다시 확인해주세요",
+                errorText = "아이디와 비밀번호를 다시 확인해주세요",
                 visualTransformation = PasswordVisualTransformation(),
                 icon = {}
             )

--- a/ui/design-system/src/main/java/com/jusicool/design_system/component/textField/JusicoolTextField.kt
+++ b/ui/design-system/src/main/java/com/jusicool/design_system/component/textField/JusicoolTextField.kt
@@ -84,7 +84,7 @@ fun JusicoolTextField(
             ) {
                 Text(
                     text = errorText,
-                    color = colors.error,
+                    color = if(isError) colors.error else colors.white,
                     style = typography.label
                 )
 


### PR DESCRIPTION
## 💡 개요
JusicoolTextField에서 isError가 true인 경우, 버튼(예: 로그인 버튼)을 누르지 않아도 errorText가 항상 즉시 화면에 노출되는 문제가 있습니다.

## 📃 작업내용
* errorText에 조건부 렌더링 로직 추가

## 🔀 변경사항
X

## 🙋‍♂️ 질문사항
X

## 🍴 사용방법
X

## 🎸 기타
X