### PR TITLE
🔀 ::  (#146) - orderhistoryviewmodel의 트리거를 정상자독하도록 수정했습니다

### DIFF
--- a/domain/entity/src/main/java/com/jusicool/entity/orderHistory/OrderHistory.kt
+++ b/domain/entity/src/main/java/com/jusicool/entity/orderHistory/OrderHistory.kt
@@ -30,12 +30,12 @@ enum class OrderType {
 }
 
 enum class ReserveType {
-    RESERVE, // 예약 주문
-    NOW,      // 즉시 주문
+    RESERVE,    // 예약 주문
+    IMMEDIATE,  // 즉시 주문
 }
 
 enum class OrderStatus {
     COMPLETED,   // 주문 완료
     PENDING,     // 대기 중
-    CANCELED,   // 취소됨
+    CANCELED,    // 취소됨
 }

--- a/domain/entity/src/main/java/com/jusicool/entity/orderHistory/OrderHistoryType.kt
+++ b/domain/entity/src/main/java/com/jusicool/entity/orderHistory/OrderHistoryType.kt
@@ -1,6 +1,6 @@
 package com.jusicool.entity.orderHistory
 
-enum class OrderHistoryType(val value: String) {
-    COMPLETED("completed"),
-    RESERVE("reserve")
+enum class OrderHistoryType{
+    COMPLETED,
+    RESERVE,
 }

--- a/domain/usecase/src/main/java/com/jusicool/usecase/order/GetOrderHistoryUseCase.kt
+++ b/domain/usecase/src/main/java/com/jusicool/usecase/order/GetOrderHistoryUseCase.kt
@@ -10,5 +10,5 @@ class GetOrderHistoryUseCase @Inject constructor(
     private val orderRepository: OrderRepository
 ) {
     operator fun invoke(type: OrderHistoryType): Flow<List<OrderHistory>> =
-        orderRepository.getOrderHistory(type = type.value)
+        orderRepository.getOrderHistory(type = type.name)
 }

--- a/feature/orderHistory/src/main/java/com/meister/orderhistory/view/OrderHistoryRoute.kt
+++ b/feature/orderHistory/src/main/java/com/meister/orderhistory/view/OrderHistoryRoute.kt
@@ -331,7 +331,12 @@ private fun ReservedOrderList(
 private fun OrderHistoryItem(data: OrderHistory) {
     JusicoolTheme { colors, typography ->
 
+        val orderTypeText = if (data.isBuyOrder()) "구매" else "판매"
+        val orderStatusText = if (data.isCompleted()) "완료" else "예약"
+        val orderPriceText = "${data.calculateTotalPrice().formatMoney()}원"
+
         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+
             Text(
                 text = data.market,
                 style = typography.bodySmall,
@@ -339,8 +344,7 @@ private fun OrderHistoryItem(data: OrderHistory) {
             )
 
             Text(
-                text = "${data.calculateTotalPrice().formatMoney()}" +
-                        "원 구매${if (data.isBuyOrder()) "완료" else "예약"}",
+                text = "$orderPriceText $orderTypeText$orderStatusText",
                 style = typography.label,
                 color = if (data.isBuyOrder()) colors.error else colors.main,
             )

--- a/feature/orderHistory/src/main/java/com/meister/orderhistory/view/OrderHistoryRoute.kt
+++ b/feature/orderHistory/src/main/java/com/meister/orderhistory/view/OrderHistoryRoute.kt
@@ -332,6 +332,7 @@ private fun OrderHistoryItem(data: OrderHistory) {
             Text(
                 text = data.market,
                 style = typography.bodySmall,
+                color = colors.black
             )
 
             Text(

--- a/feature/orderHistory/src/main/java/com/meister/orderhistory/view/OrderHistoryRoute.kt
+++ b/feature/orderHistory/src/main/java/com/meister/orderhistory/view/OrderHistoryRoute.kt
@@ -39,6 +39,9 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
 import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
+import com.jusicool.entity.orderHistory.OrderStatus.*
+import com.jusicool.entity.orderHistory.OrderType.*
+import com.jusicool.entity.orderHistory.ReserveType.*
 
 
 @Composable
@@ -102,38 +105,38 @@ private fun OrderHistoryScreenPreview() {
         OrderHistory(
             id = 1,
             market = "KRW-BTC",
-            orderType = com.jusicool.entity.orderHistory.OrderType.BUY,
-            reserveType = com.jusicool.entity.orderHistory.ReserveType.NOW,
+            orderType = BUY,
+            reserveType = IMMEDIATE,
             quantity = 3,
             price = 50000,
-            status = com.jusicool.entity.orderHistory.OrderStatus.COMPLETED
+            status = COMPLETED
         ),
         OrderHistory(
             id = 2,
             market = "KRW-ETH",
-            orderType = com.jusicool.entity.orderHistory.OrderType.SELL,
-            reserveType = com.jusicool.entity.orderHistory.ReserveType.NOW,
+            orderType = SELL,
+            reserveType = IMMEDIATE,
             quantity = 1,
             price = 35000,
-            status = com.jusicool.entity.orderHistory.OrderStatus.COMPLETED
+            status = COMPLETED
         ),
         OrderHistory(
             id = 3,
             market = "KRW-XRP",
-            orderType = com.jusicool.entity.orderHistory.OrderType.BUY,
-            reserveType = com.jusicool.entity.orderHistory.ReserveType.NOW,
+            orderType = BUY,
+            reserveType = IMMEDIATE,
             quantity = 10,
             price = 600,
-            status = com.jusicool.entity.orderHistory.OrderStatus.COMPLETED
+            status = COMPLETED
         ),
         OrderHistory(
             id = 4,
             market = "KRW-SOL",
-            orderType = com.jusicool.entity.orderHistory.OrderType.SELL,
-            reserveType = com.jusicool.entity.orderHistory.ReserveType.NOW,
+            orderType = SELL,
+            reserveType = IMMEDIATE,
             quantity = 2,
             price = 120000,
-            status = com.jusicool.entity.orderHistory.OrderStatus.COMPLETED
+            status = COMPLETED
         )
     )
 
@@ -141,38 +144,38 @@ private fun OrderHistoryScreenPreview() {
         OrderHistory(
             id = 5,
             market = "KRW-ADA",
-            orderType = com.jusicool.entity.orderHistory.OrderType.SELL,
-            reserveType = com.jusicool.entity.orderHistory.ReserveType.RESERVE,
+            orderType = SELL,
+            reserveType = RESERVE,
             quantity = 5,
             price = 1500,
-            status = com.jusicool.entity.orderHistory.OrderStatus.PENDING
+            status = PENDING
         ),
         OrderHistory(
             id = 6,
             market = "KRW-DOGE",
-            orderType = com.jusicool.entity.orderHistory.OrderType.BUY,
-            reserveType = com.jusicool.entity.orderHistory.ReserveType.RESERVE,
+            orderType = BUY,
+            reserveType = RESERVE,
             quantity = 20,
             price = 100,
-            status = com.jusicool.entity.orderHistory.OrderStatus.PENDING
+            status = PENDING
         ),
         OrderHistory(
             id = 7,
             market = "KRW-DOT",
-            orderType = com.jusicool.entity.orderHistory.OrderType.SELL,
-            reserveType = com.jusicool.entity.orderHistory.ReserveType.RESERVE,
+            orderType = SELL,
+            reserveType = RESERVE,
             quantity = 4,
             price = 8000,
-            status = com.jusicool.entity.orderHistory.OrderStatus.PENDING
+            status = PENDING
         ),
         OrderHistory(
             id = 8,
             market = "KRW-LINK",
-            orderType = com.jusicool.entity.orderHistory.OrderType.BUY,
-            reserveType = com.jusicool.entity.orderHistory.ReserveType.RESERVE,
+            orderType = BUY,
+            reserveType = RESERVE,
             quantity = 3,
             price = 9000,
-            status = com.jusicool.entity.orderHistory.OrderStatus.PENDING
+            status = PENDING
         )
     )
 

--- a/feature/orderHistory/src/main/java/com/meister/orderhistory/viewModel/OrderHistoryViewModel.kt
+++ b/feature/orderHistory/src/main/java/com/meister/orderhistory/viewModel/OrderHistoryViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.jusicool.entity.orderHistory.OrderHistory
 import com.jusicool.entity.orderHistory.OrderHistoryType
 import com.jusicool.usecase.order.GetOrderHistoryUseCase
+import com.jusicool.utils.Logger
 import com.meister.orderhistory.viewModel.uiState.CompletedOrderHistoryUiState
 import com.meister.orderhistory.viewModel.uiState.ReservedOrderHistoryUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -40,9 +41,13 @@ internal class OrderHistoryViewModel @Inject constructor(
                         )
                     }
                     .onStart {
+                        Logger.d("reservedOrderHistoryUiState", "데이터 로딩 시작")
+
                         emit(ReservedOrderHistoryUiState(isLoading = true))
                     }
                     .catch { e ->
+                        Logger.e("reservedOrderHistoryUiState", "에러 발생: ${e.message}", e)
+
                         emit(
                             ReservedOrderHistoryUiState(
                                 isLoading = false,
@@ -79,9 +84,13 @@ internal class OrderHistoryViewModel @Inject constructor(
                         )
                     }
                     .onStart {
+                        Logger.d("completedOrderHistoryUiState", "데이터 로딩 시작")
+
                         emit(CompletedOrderHistoryUiState(isLoading = true))
                     }
                     .catch { e ->
+                        Logger.e("completedOrderHistoryUiState", "에러 발생: ${e.message}", e)
+
                         emit(
                             CompletedOrderHistoryUiState(
                                 isLoading = false,

--- a/feature/orderHistory/src/main/java/com/meister/orderhistory/viewModel/OrderHistoryViewModel.kt
+++ b/feature/orderHistory/src/main/java/com/meister/orderhistory/viewModel/OrderHistoryViewModel.kt
@@ -24,7 +24,7 @@ internal class OrderHistoryViewModel @Inject constructor(
     private val getOrderHistoryUseCase: GetOrderHistoryUseCase
 ) : ViewModel() {
 
-    private val reservedRefreshTrigger = MutableStateFlow(Unit)
+    private val reservedRefreshTrigger = MutableStateFlow(0)
 
     internal val reservedOrderHistoryUiState: StateFlow<ReservedOrderHistoryUiState> =
         reservedRefreshTrigger
@@ -57,9 +57,7 @@ internal class OrderHistoryViewModel @Inject constructor(
         reservedRefreshTrigger.value = Unit
     }
 
-
-
-    private val completedRefreshTrigger = MutableStateFlow(Unit)
+    private val completedRefreshTrigger = MutableStateFlow(0)
 
     internal val completedOrderHistoryUiState: StateFlow<CompletedOrderHistoryUiState> =
         completedRefreshTrigger

--- a/feature/orderHistory/src/main/java/com/meister/orderhistory/viewModel/OrderHistoryViewModel.kt
+++ b/feature/orderHistory/src/main/java/com/meister/orderhistory/viewModel/OrderHistoryViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.jusicool.entity.orderHistory.OrderHistory
 import com.jusicool.entity.orderHistory.OrderHistoryType
 import com.jusicool.usecase.order.GetOrderHistoryUseCase
+import com.jusicool.utils.Logger
 import com.meister.orderhistory.viewModel.uiState.CompletedOrderHistoryUiState
 import com.meister.orderhistory.viewModel.uiState.ReservedOrderHistoryUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -54,7 +55,8 @@ internal class OrderHistoryViewModel @Inject constructor(
             )
 
     internal fun refreshReservedOrders() {
-        reservedRefreshTrigger.value = Unit
+        reservedRefreshTrigger.value += 1
+        Logger.d("refreshReservedOrders", "Count : ${reservedRefreshTrigger.value}")
     }
 
     private val completedRefreshTrigger = MutableStateFlow(0)
@@ -87,6 +89,7 @@ internal class OrderHistoryViewModel @Inject constructor(
             )
 
     internal fun refreshCompletedOrders() {
-        completedRefreshTrigger.value = Unit
+        completedRefreshTrigger.value += 1
+        Logger.d("refreshCompletedOrders", "Count : ${completedRefreshTrigger.value}")
     }
 }

--- a/feature/orderHistory/src/main/java/com/meister/orderhistory/viewModel/OrderHistoryViewModel.kt
+++ b/feature/orderHistory/src/main/java/com/meister/orderhistory/viewModel/OrderHistoryViewModel.kt
@@ -5,12 +5,11 @@ import androidx.lifecycle.viewModelScope
 import com.jusicool.entity.orderHistory.OrderHistory
 import com.jusicool.entity.orderHistory.OrderHistoryType
 import com.jusicool.usecase.order.GetOrderHistoryUseCase
-import com.jusicool.utils.Logger
 import com.meister.orderhistory.viewModel.uiState.CompletedOrderHistoryUiState
 import com.meister.orderhistory.viewModel.uiState.ReservedOrderHistoryUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
@@ -18,6 +17,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -25,10 +25,11 @@ internal class OrderHistoryViewModel @Inject constructor(
     private val getOrderHistoryUseCase: GetOrderHistoryUseCase
 ) : ViewModel() {
 
-    private val reservedRefreshTrigger = MutableStateFlow(0)
+    private val reservedRefreshTrigger = MutableSharedFlow<Unit>()
 
-    internal val reservedOrderHistoryUiState: StateFlow<ReservedOrderHistoryUiState> =
+    val reservedOrderHistoryUiState: StateFlow<ReservedOrderHistoryUiState> =
         reservedRefreshTrigger
+            .onStart { emit(Unit) }
             .flatMapLatest {
                 getOrderHistoryUseCase(OrderHistoryType.RESERVE)
                     .map<List<OrderHistory>, ReservedOrderHistoryUiState> {
@@ -39,11 +40,9 @@ internal class OrderHistoryViewModel @Inject constructor(
                         )
                     }
                     .onStart {
-                        Logger.d("reservedOrderHistoryUiState", "데이터 로딩 시작")
                         emit(ReservedOrderHistoryUiState(isLoading = true))
                     }
                     .catch { e ->
-                        Logger.e("reservedOrderHistoryUiState", "에러 발생: ${e.message}", e)
                         emit(
                             ReservedOrderHistoryUiState(
                                 isLoading = false,
@@ -53,21 +52,23 @@ internal class OrderHistoryViewModel @Inject constructor(
                     }
             }
             .stateIn(
-                viewModelScope,
-                SharingStarted.WhileSubscribed(5_000),
-                ReservedOrderHistoryUiState(isLoading = true)
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+                initialValue = ReservedOrderHistoryUiState(isLoading = true)
             )
 
-
-    internal fun refreshReservedOrders() {
-        reservedRefreshTrigger.value += 1
-        Logger.d("refreshReservedOrders", "Count : ${reservedRefreshTrigger.value}")
+    fun refreshReservedOrders() {
+        viewModelScope.launch {
+            reservedRefreshTrigger.emit(Unit)
+        }
     }
 
-    private val completedRefreshTrigger = MutableStateFlow(0)
 
-    internal val completedOrderHistoryUiState: StateFlow<CompletedOrderHistoryUiState> =
+    private val completedRefreshTrigger = MutableSharedFlow<Unit>()
+
+    val completedOrderHistoryUiState: StateFlow<CompletedOrderHistoryUiState> =
         completedRefreshTrigger
+            .onStart { emit(Unit) }
             .flatMapLatest {
                 getOrderHistoryUseCase(OrderHistoryType.COMPLETED)
                     .map<List<OrderHistory>, CompletedOrderHistoryUiState> {
@@ -78,11 +79,9 @@ internal class OrderHistoryViewModel @Inject constructor(
                         )
                     }
                     .onStart {
-                        Logger.d("completedOrderHistoryUiState", "데이터 로딩 시작")
                         emit(CompletedOrderHistoryUiState(isLoading = true))
                     }
                     .catch { e ->
-                        Logger.e("completedOrderHistoryUiState", "에러 발생: ${e.message}", e)
                         emit(
                             CompletedOrderHistoryUiState(
                                 isLoading = false,
@@ -92,13 +91,14 @@ internal class OrderHistoryViewModel @Inject constructor(
                     }
             }
             .stateIn(
-                viewModelScope,
-                SharingStarted.WhileSubscribed(5_000),
-                CompletedOrderHistoryUiState(isLoading = true)
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+                initialValue = CompletedOrderHistoryUiState(isLoading = true)
             )
 
-    internal fun refreshCompletedOrders() {
-        completedRefreshTrigger.value += 1
-        Logger.d("refreshCompletedOrders", "Count : ${completedRefreshTrigger.value}")
+    fun refreshCompletedOrders() {
+        viewModelScope.launch {
+            completedRefreshTrigger.emit(Unit)
+        }
     }
 }

--- a/feature/orderHistory/src/main/java/com/meister/orderhistory/viewModel/OrderHistoryViewModel.kt
+++ b/feature/orderHistory/src/main/java/com/meister/orderhistory/viewModel/OrderHistoryViewModel.kt
@@ -38,12 +38,16 @@ internal class OrderHistoryViewModel @Inject constructor(
                             errorMessage = null
                         )
                     }
-                    .onStart { emit(ReservedOrderHistoryUiState(isLoading = true)) }
-                    .catch {
+                    .onStart {
+                        Logger.d("reservedOrderHistoryUiState", "데이터 로딩 시작")
+                        emit(ReservedOrderHistoryUiState(isLoading = true))
+                    }
+                    .catch { e ->
+                        Logger.e("reservedOrderHistoryUiState", "에러 발생: ${e.message}", e)
                         emit(
                             ReservedOrderHistoryUiState(
                                 isLoading = false,
-                                errorMessage = it.message
+                                errorMessage = e.message
                             )
                         )
                     }
@@ -53,6 +57,7 @@ internal class OrderHistoryViewModel @Inject constructor(
                 SharingStarted.WhileSubscribed(5_000),
                 ReservedOrderHistoryUiState(isLoading = true)
             )
+
 
     internal fun refreshReservedOrders() {
         reservedRefreshTrigger.value += 1
@@ -72,12 +77,16 @@ internal class OrderHistoryViewModel @Inject constructor(
                             errorMessage = null
                         )
                     }
-                    .onStart { emit(CompletedOrderHistoryUiState(isLoading = true)) }
-                    .catch {
+                    .onStart {
+                        Logger.d("completedOrderHistoryUiState", "데이터 로딩 시작")
+                        emit(CompletedOrderHistoryUiState(isLoading = true))
+                    }
+                    .catch { e ->
+                        Logger.e("completedOrderHistoryUiState", "에러 발생: ${e.message}", e)
                         emit(
                             CompletedOrderHistoryUiState(
                                 isLoading = false,
-                                errorMessage = it.message
+                                errorMessage = e.message
                             )
                         )
                     }


### PR DESCRIPTION
## 💡 개요

트리거가 Flow의 새로운 값이 이전의 값과 같으면 옵저버에 전달하지 않는 특정때문에 정상 작동하지 않았습니다

## 📃 작업내용

트리거가 Flow의 새로운 값이 이전의 값과 같으면 옵저버에 전달하지 않는 특정때문에 정상 작동하지 않아서 
Int값을 1씩 증가하는식으로 변경하였고
리프래시 한 회수를 로그로 남기도록 로거를 추가했습니다

## 🔀 변경사항

https://github.com/Jusicool-Ver-2-0/Jusicool-Android/compare/fix/146-orderhistoryviewmodel-triger-fix?expand=1#diff-ce0a31882782073313422485d99d5345c5abe680ff1ea39e21e6b482a4cbc4bc

## 🙋‍♂️ 질문사항
x
## 🍴 사용방법
x
## 🎸 기타
x