### PR TITLE
🔀 :: (#148) - order history api의 응답값이 변경되었습니다

### DIFF
--- a/data/model/src/main/java/com/jusicool/model/mapper/order/OrderHistoryMapper.kt
+++ b/data/model/src/main/java/com/jusicool/model/mapper/order/OrderHistoryMapper.kt
@@ -12,7 +12,8 @@ fun OrderHistoryResponse.toEntity(): OrderHistory =
         market = this.market,
         orderType = OrderType.valueOf(this.orderType),
         reserveType = ReserveType.valueOf(this.reserveType),
+        status = OrderStatus.valueOf(this.status),
         quantity = this.quantity,
-        price = this.price,
-        status = OrderStatus.valueOf(this.status)
+        executePrice = this.executePrice,
+        reservePrice = this.reservePrice
     )

--- a/data/model/src/main/java/com/jusicool/model/order/OrderHistoryResponse.kt
+++ b/data/model/src/main/java/com/jusicool/model/order/OrderHistoryResponse.kt
@@ -8,8 +8,9 @@ data class OrderHistoryResponse(
     val id: Int,
     val market: String,
     @Json(name = "order_type") val orderType: String,
-    val price: Int,
-    val quantity: Int,
     @Json(name = "reserve_type") val reserveType: String,
-    val status: String
+    val status: String,
+    val quantity: Int,
+    @Json(name = "execute_price") val executePrice: Int?,
+    @Json(name = "reserve_price") val reservePrice: Int?,
 )

--- a/domain/entity/src/main/java/com/jusicool/entity/orderHistory/OrderHistory.kt
+++ b/domain/entity/src/main/java/com/jusicool/entity/orderHistory/OrderHistory.kt
@@ -12,7 +12,8 @@ data class OrderHistory(
 ) {
     init {
         require(quantity > 0) { "주문 수량은 0보다 커야 합니다." }
-        require(price >= 0) { "주문 가격은 음수가 될 수 없습니다." }
+        require(executePrice == null || executePrice >= 0) { "체결 가격은 null이거나 0 이상이어야 합니다." }
+        require(reservePrice == null || reservePrice >= 0) { "예약 가격은 null이거나 0 이상이어야 합니다." }
         require(market.isNotBlank()) { "마켓 정보는 비어 있을 수 없습니다." }
     }
 
@@ -22,7 +23,9 @@ data class OrderHistory(
 
     fun isCompleted(): Boolean = status == OrderStatus.COMPLETED
 
-    fun calculateTotalPrice(): Int = quantity * price
+    fun calculateTotalExecutePrice(): Int = quantity * (executePrice ?: 0)
+
+    fun calculateTotalReservePrice(): Int = quantity * (reservePrice ?: 0)
 }
 
 enum class OrderType {

--- a/domain/entity/src/main/java/com/jusicool/entity/orderHistory/OrderHistory.kt
+++ b/domain/entity/src/main/java/com/jusicool/entity/orderHistory/OrderHistory.kt
@@ -5,9 +5,10 @@ data class OrderHistory(
     val market: String,
     val orderType: OrderType,
     val reserveType: ReserveType,
+    val status: OrderStatus,
     val quantity: Int,
-    val price: Int,
-    val status: OrderStatus
+    val executePrice: Int?,
+    val reservePrice: Int?,
 ) {
     init {
         require(quantity > 0) { "주문 수량은 0보다 커야 합니다." }

--- a/feature/orderHistory/src/main/java/com/meister/orderhistory/view/OrderHistoryRoute.kt
+++ b/feature/orderHistory/src/main/java/com/meister/orderhistory/view/OrderHistoryRoute.kt
@@ -108,7 +108,8 @@ private fun OrderHistoryScreenPreview() {
             orderType = BUY,
             reserveType = IMMEDIATE,
             quantity = 3,
-            price = 50000,
+            executePrice = 50000,
+            reservePrice = null,
             status = COMPLETED
         ),
         OrderHistory(
@@ -117,7 +118,8 @@ private fun OrderHistoryScreenPreview() {
             orderType = SELL,
             reserveType = IMMEDIATE,
             quantity = 1,
-            price = 35000,
+            executePrice = 200000,
+            reservePrice = null,
             status = COMPLETED
         ),
         OrderHistory(
@@ -126,7 +128,8 @@ private fun OrderHistoryScreenPreview() {
             orderType = BUY,
             reserveType = IMMEDIATE,
             quantity = 10,
-            price = 600,
+            executePrice = 5000,
+            reservePrice = null,
             status = COMPLETED
         ),
         OrderHistory(
@@ -135,7 +138,8 @@ private fun OrderHistoryScreenPreview() {
             orderType = SELL,
             reserveType = IMMEDIATE,
             quantity = 2,
-            price = 120000,
+            executePrice = 50000,
+            reservePrice = null,
             status = COMPLETED
         )
     )
@@ -147,7 +151,8 @@ private fun OrderHistoryScreenPreview() {
             orderType = SELL,
             reserveType = RESERVE,
             quantity = 5,
-            price = 1500,
+            executePrice = null,
+            reservePrice = 2000,
             status = PENDING
         ),
         OrderHistory(
@@ -156,7 +161,8 @@ private fun OrderHistoryScreenPreview() {
             orderType = BUY,
             reserveType = RESERVE,
             quantity = 20,
-            price = 100,
+            executePrice = null,
+            reservePrice = 3000,
             status = PENDING
         ),
         OrderHistory(
@@ -165,7 +171,8 @@ private fun OrderHistoryScreenPreview() {
             orderType = SELL,
             reserveType = RESERVE,
             quantity = 4,
-            price = 8000,
+            executePrice = null,
+            reservePrice = 4000,
             status = PENDING
         ),
         OrderHistory(
@@ -174,7 +181,8 @@ private fun OrderHistoryScreenPreview() {
             orderType = BUY,
             reserveType = RESERVE,
             quantity = 3,
-            price = 9000,
+            executePrice = null,
+            reservePrice = 5000,
             status = PENDING
         )
     )
@@ -333,7 +341,11 @@ private fun OrderHistoryItem(data: OrderHistory) {
 
         val orderTypeText = if (data.isBuyOrder()) "구매" else "판매"
         val orderStatusText = if (data.isCompleted()) "완료" else "예약"
-        val orderPriceText = "${data.calculateTotalPrice().formatMoney()}원"
+
+        val orderPrice = if (data.isCompleted()) data.calculateTotalExecutePrice()
+        else data.calculateTotalReservePrice()
+
+        val orderPriceText = "${orderPrice.formatMoney()}원"
 
         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
 


### PR DESCRIPTION
## 💡 개요

order history api의 응답값이 변경되었습니다


## 📃 작업내용

dto와 엔티티의 필드를 추가하고 각 필드의 타입을 nullable으로 변경했고
완료 여부에 따라서 ui에 다른 값을 띄우도록 수정

## 🔀 변경사항

![image](https://github.com/user-attachments/assets/7a514543-59c3-49db-8d91-3854c3c13d20)

## 🙋‍♂️ 질문사항
x
## 🍴 사용방법
x
## 🎸 기타
x