### PR TITLE
🔀 :: (#199) - monthlyincomescreenpreview add previewparameterprovider

### DIFF
--- a/feature/assets/src/main/java/com/meister/assets/view/MonthlyIncomeRoute.kt
+++ b/feature/assets/src/main/java/com/meister/assets/view/MonthlyIncomeRoute.kt
@@ -26,16 +26,17 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.jusicool.design_system.component.topbar.JusicoolTopBar
+import com.jusicool.design_system.icon.LeftClarityArrowLineIcon
 import com.jusicool.design_system.theme.JusicoolTheme
 import com.jusicool.utils.formatMoney
 import com.meister.assets.component.DoughnutChart
+import com.meister.assets.view.previewProvider.MonthlyIncomeUiStateProvider
 import com.meister.assets.viewModel.MonthlyIncomeViewModel
 import com.meister.assets.viewModel.uiState.MonthlyIncomeUiState
-import com.jusicool.design_system.icon.LeftClarityArrowLineIcon
-import kotlinx.collections.immutable.persistentListOf
 import kotlin.math.abs
 import kotlin.random.Random
 
@@ -183,23 +184,12 @@ private fun MonthlyIncomeScreen(
 
 @Preview
 @Composable
-private fun MonthlyIncomeScreenPreview() {
+private fun MonthlyIncomeScreenPreview(
+    @PreviewParameter(MonthlyIncomeUiStateProvider::class)
+    uiState: MonthlyIncomeUiState
+) {
     MonthlyIncomeScreen(
-        uiState = MonthlyIncomeUiState(
-            isLoading = false,
-            myMoney = 1000000,
-            moneyChangeFromLastMonth = 50,
-            availableOrderAmount = 200,
-            investedAmount = 800,
-            ownedStocks = persistentListOf(
-                "dqdw" to 100,
-                "dqdw" to 100,
-                "#34ㄺㄷㅈ" to 120,
-                "dwqe" to 100,
-                "dwqe1" to 100
-            ),
-            errorMessage = null
-        ),
+        uiState = uiState,
         navigateToBack = {},
     )
 }

--- a/feature/assets/src/main/java/com/meister/assets/view/previewProvider/MonthlyIncomeUiStateProvider.kt
+++ b/feature/assets/src/main/java/com/meister/assets/view/previewProvider/MonthlyIncomeUiStateProvider.kt
@@ -1,0 +1,35 @@
+package com.meister.assets.view.previewProvider
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.meister.assets.viewModel.uiState.MonthlyIncomeUiState
+import kotlinx.collections.immutable.persistentListOf
+
+class MonthlyIncomeUiStateProvider : PreviewParameterProvider<MonthlyIncomeUiState> {
+    override val values = sequenceOf(
+        MonthlyIncomeUiState(
+            isLoading = false,
+            myMoney = 1_000_000,
+            moneyChangeFromLastMonth = 50_000,
+            availableOrderAmount = 200_000,
+            investedAmount = 800_000,
+            ownedStocks = persistentListOf(
+                "삼성전자" to 100,
+                "카카오" to 200,
+                "네이버" to 150,
+            ),
+            errorMessage = null
+        ),
+        MonthlyIncomeUiState(
+            isLoading = false,
+            myMoney = 500_000,
+            moneyChangeFromLastMonth = -30_000,
+            availableOrderAmount = 50_000,
+            investedAmount = 450_000,
+            ownedStocks = persistentListOf(
+                "LG에너지솔루션" to 80,
+                "현대차" to 120
+            ),
+            errorMessage = null
+        )
+    )
+}


### PR DESCRIPTION
## 💡 개요

monthlyincomescreenpreview 에 대한 previewparameterprovider를 구현하고 적용했습니다 

<img width="675" height="749" alt="image" src="https://github.com/user-attachments/assets/655850cf-7b8c-423f-a405-f218177055f7" />

## 📃 작업내용

previewparameterprovider 구현
monthlyincomescreenpreview 에 previewparameterprovider  적용

## 🔀 변경사항

<img width="288" height="142" alt="image" src="https://github.com/user-attachments/assets/abc8958b-006c-4100-bf39-99b934f53dcc" />

## 🙋‍♂️ 질문사항
x
## 🍴 사용방법

<img width="454" height="173" alt="image" src="https://github.com/user-attachments/assets/3e4e2b79-9245-4cc5-afb5-93b3aec7469c" />

## 🎸 기타
x