### PR TITLE
🔀 :: (#201)  TopLevelDestination에서 monthlyIncomeRoute를 삭제 했습니다

### DIFF
--- a/app/src/main/java/com/jusicool/jusicool_android/ui/TopLevelDestination.kt
+++ b/app/src/main/java/com/jusicool/jusicool_android/ui/TopLevelDestination.kt
@@ -2,12 +2,11 @@ package com.jusicool.jusicool_android.ui
 
 import com.jusicool.account.navigation.accountRoute
 import com.jusicool.design_system.R
-import com.meister.assets.navigation.monthlyIncomeRoute
 import com.meister.investmentsearch.navigation.chartListRoute
 
 sealed class TopLevelDestination(val route: String, val icon: Int, val label: String) {
     object ASSET : TopLevelDestination(route = accountRoute, icon = R.drawable.pie_chartfilled, label = "자산")
     object CHART : TopLevelDestination(route = chartListRoute, icon = R.drawable.chart_line, label = "차트")
     object NEWS : TopLevelDestination(route = "newsRoute", icon = R.drawable.material_symbols_news_outline, label = "뉴스")
-    object MY : TopLevelDestination(route = monthlyIncomeRoute, icon = R.drawable.account, label = "마이 페이지")
+    object MY : TopLevelDestination(route = "myPage", icon = R.drawable.account, label = "마이 페이지")
 }


### PR DESCRIPTION
## 💡 개요

더이상 네비게이션 바에서 monthlyIncomeRoute로 이동 할 수 없도록 수정했습니다

## 📃 작업내용

[♻️ :: TopLevelDestination에서의 MY의 destination 을 monthlyIncomeRoute에서 myPage로 임시 변경 하였습니다](https://github.com/Jusicool-Ver-2-0/Jusicool-Android/commit/745c0e97e31c18a8c7d8ff87c7b5a659c699c5eb) 

## 🔀 변경사항
<img width="1941" height="356" alt="image" src="https://github.com/user-attachments/assets/0cf7220f-cc58-4bf7-9d02-b60ccb96327d" />

## 🙋‍♂️ 질문사항
ｘ
## 🍴 사용방법
ｘ
## 🎸 기타
ｘ