### PR TITLE
🔀 :: (#207) - 웹소켓의 파싱 로직에 문제가 있습니다

### DIFF
--- a/data/model/src/main/java/com/jusicool/model/koreaInvestment/ws/StockPriceSummary.kt
+++ b/data/model/src/main/java/com/jusicool/model/koreaInvestment/ws/StockPriceSummary.kt
@@ -9,9 +9,11 @@ data class StockPriceSummary(
     val time: String,            // STCK_CNTG_HOUR (1)
 ) {
     companion object {
+        const val STOCK_PRICE_FIELDS_COUNT = 46
+
         fun parseStockPriceSummary(rawData: String): StockPriceSummary? {
             val splitData = rawData.split("^")
-            if (splitData.size <= 52) return null
+            if (splitData.size < STOCK_PRICE_FIELDS_COUNT) return null
 
             return try {
                 StockPriceSummary(

--- a/data/network/src/main/java/com/jusicool/network/datasource/koreaInvestment/ws/KoreaInvestmentWebSocketManager.kt
+++ b/data/network/src/main/java/com/jusicool/network/datasource/koreaInvestment/ws/KoreaInvestmentWebSocketManager.kt
@@ -3,12 +3,19 @@ package com.jusicool.network.datasource.koreaInvestment.ws
 import android.util.Log
 import com.jusicool.model.koreaInvestment.ws.StockPriceSummary
 import com.jusicool.network.util.KoreaInvestmentAuthManager
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import okhttp3.*
+import kotlinx.coroutines.launch
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
 import org.json.JSONObject
 import javax.inject.Inject
 import javax.inject.Named
@@ -98,23 +105,41 @@ class KoreaInvestmentWebSocketManager @Inject constructor(
     private fun parseAndEmit(message: String) {
         if (!message.startsWith("0|")) return
 
-        val payload = message.split("|").getOrNull(3) ?: return
-        val stockCode = payload.split("^").getOrNull(0) ?: return
+        val parts = message.split("|")
+        val count = parts.getOrNull(2)?.toIntOrNull() ?: return
+        val payload = parts.getOrNull(3) ?: return
 
-        val parsed = StockPriceSummary.parseStockPriceSummary(payload) ?: return
+        val payloadParts = payload.split("^")
 
-        // 기존 리스트에서 해당 종목이 있으면 교체, 없으면 추가
+        val parsedList = mutableListOf<StockPriceSummary>()
+
+        repeat(count) { i ->
+            val start = i * StockPriceSummary.STOCK_PRICE_FIELDS_COUNT
+            val end = start + StockPriceSummary.STOCK_PRICE_FIELDS_COUNT
+            if (end <= payloadParts.size) {
+                val record = payloadParts.subList(start, end).joinToString("^")
+                StockPriceSummary.parseStockPriceSummary(record)?.let { parsed ->
+                    parsedList.add(parsed)
+                }
+            }
+        }
+
         _stockTickerListFlow.update { currentList ->
             val mutableList = currentList.toMutableList()
-            val index = mutableList.indexOfFirst { it.stockCode == stockCode }
-            if (index >= 0) {
-                mutableList[index] = parsed
-            } else {
-                mutableList.add(parsed)
+            parsedList.forEach { parsed ->
+                val index = mutableList.indexOfFirst { it.stockCode == parsed.stockCode }
+                if (index >= 0) {
+                    mutableList[index] = parsed
+                } else {
+                    mutableList.add(parsed)
+                }
             }
             mutableList.toList()
         }
 
-        Log.d("WebSocket", "📈 $stockCode 업데이트: $parsed")
+        if (parsedList.isNotEmpty()) {
+            val codes = parsedList.joinToString(", ") { it.stockCode }
+            Log.d("WebSocket", "📈 ${parsedList.size}건 업데이트 완료 → [$codes]")
+        }
     }
 }

--- a/data/repository/src/main/java/com/jusicool/repository/WsKoreaInvestmentRepositoryImpl.kt
+++ b/data/repository/src/main/java/com/jusicool/repository/WsKoreaInvestmentRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package com.jusicool.repository
 
+import android.util.Log
 import com.jusicool.entity.price.AssetsCurrentPrice
+import com.jusicool.model.koreaInvestment.ws.StockPriceSummary
 import com.jusicool.model.mapper.koreaInvestment.toEntity
 import com.jusicool.network.datasource.koreaInvestment.ws.KoreaInvestmentWebSocketManagerInterface
 import kotlinx.coroutines.channels.awaitClose
@@ -22,13 +24,19 @@ class WsKoreaInvestmentRepositoryImpl @Inject constructor(
             val job = launch {
                 webSocketManager.stockTickerMapFlow
                     .filterNotNull()
-                    .map { list -> list.map { it.toEntity() } }
-                    .collect { trySend(it).isSuccess }
+                    .map { list -> list.map(StockPriceSummary::toEntity) }
+                    .collect { data ->
+                        val result = trySend(data)
+                        if (result.isFailure) {
+                            Log.d("WsRepository", "Flow send 실패: $result")
+                        }
+                    }
             }
 
             awaitClose {
                 webSocketManager.disconnect()
                 job.cancel()
+                Log.d("WsRepository", "Flow 종료")
             }
         }
 


### PR DESCRIPTION
## 💡 개요

현재 웹소켓이 한번에 2개 이상의 데이터가 전달되면 하나의 데이터만 파싱을 합니다.
또한 하나의 데이터만 전달이 되면 길이 부족으로 파싱을 하지 않습니다

수정후 -> 

https://github.com/user-attachments/assets/6d4d1da9-8997-4cd1-92aa-2d5bcc98da3f

## 📃 작업내용

<img width="1533" height="348" alt="image" src="https://github.com/user-attachments/assets/3edc9b31-0319-42e3-9459-f0768f9db7c2" />

데이터 규칙에 따라서 데이터 건수값 만큼 파싱을 하도록 수정

## 🔀 변경사항

<img width="1128" height="357" alt="image" src="https://github.com/user-attachments/assets/9bd33afb-1606-4cd6-9f9c-7327482267a6" />

## 🙋‍♂️ 질문사항
x
## 🍴 사용방법
x
## 🎸 기타
x